### PR TITLE
Ask for collectible address

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -9,6 +9,7 @@ export interface BuildOptions {
     port: number;
     makerFee: number;
     takerFee: number;
+    collectibleAddress: string;
 }
 
 function getNetworkId(network: Network): number {
@@ -49,6 +50,7 @@ services:${isGanache ? ganacheService : ''}
       REACT_APP_DEFAULT_BASE_PATH: '${basePath}'
       REACT_APP_THEME_NAME: '${theme}'
       REACT_APP_COLLECTIBLES_SOURCE: '${collectiblesSource}'
+      REACT_APP_COLLECTIBLE_ADDRESS: '${options.collectibleAddress}'
       REACT_APP_RELAYER_URL: 'http://localhost:3000/v2'
     command: yarn build
     volumes:

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,8 @@ import { buildDockerComposeYml, BuildOptions, Network } from './build';
 
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 
+const mockERC721Address = '0x07f96aa816c1f244cbc6ef114bb2b023ba54a2eb';
+
 function getRpcUrl(network: Network): string {
     switch (network) {
         case 'mainnet':
@@ -21,6 +23,8 @@ function getRpcUrl(network: Network): string {
             return 'http://localhost:8545/';
     }
 }
+
+const isAddress = (s: string) => /(0x)?[0-9a-fA-F]{40}/.test(s);
 
 async function main() {
     const networkChoices: Array<{ name: string; value: Network }> = [
@@ -73,11 +77,21 @@ async function main() {
         },
         {
             type: 'input',
+            name: 'collectibleAddress',
+            message: 'Enter the address of the collectible:',
+            default: ZERO_ADDRESS,
+            validate: (answer: string) => {
+                return isAddress(answer) ? true : 'Please enter a valid address';
+            },
+            when: (answers: any) => answers.tokenType === 'ERC721' && answers.network !== 'ganache',
+        },
+        {
+            type: 'input',
             name: 'feeRecipient',
             message: 'Enter the fee recipient:',
             default: ZERO_ADDRESS,
             validate: (answer: string) => {
-                return /(0x)?[0-9a-fA-F]{40}/.test(answer) ? true : 'Please enter a valid address';
+                return isAddress(answer) ? true : 'Please enter a valid address';
             },
         },
         {
@@ -131,6 +145,7 @@ async function main() {
         port: answers.port,
         makerFee: answers.makerFee || 0,
         takerFee: answers.takerFee || 0,
+        collectibleAddress: answers.collectibleAddress || mockERC721Address,
     };
 
     const dockerComposeYml = buildDockerComposeYml(options);


### PR DESCRIPTION
If the user selects `ERC721` as the token, and if they don't select `ganache` as the network, the wizards asks for the address of the collectible.

Notice that this depends on an open [PR](https://github.com/0xProject/0x-launch-kit-frontend/pull/457) in the frontend, so this won't do anything until that PR is merged and the frontend image is updated.