### PR TITLE
Show some message while app is building

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -56,9 +56,11 @@ services:${isGanache ? ganacheService : ''}
       REACT_APP_COLLECTIBLE_NAME: '${options.collectibleName}'
       REACT_APP_COLLECTIBLE_DESCRIPTION: '${options.collectibleDescription}'
       REACT_APP_RELAYER_URL: 'http://localhost:3000/v2'
-    command: yarn build
+    command: bash -c 'cp templates/building.html production-build/index.html && yarn build && cp -a build/. production-build'
     volumes:
-        - frontend-assets:/app/build
+        - frontend-assets:/app/production-build
+    depends_on:
+        - nginx
   backend:
     image: 0xorg/launch-kit-backend
     environment:


### PR DESCRIPTION
Closes #5. Depends on https://github.com/0xProject/0x-launch-kit-frontend/pull/499 being merged and the new image being published.

This copies a template showing a message before starting to build the app. After the build finishes, the message is overwritten by the built app.

---

Some extra details in case anyone cares:

First, I had to serve the assets from `production-build` instead of `build`, because `create-react-app` cleans the whole `build` directory when it starts, and so the message was being deleted.

I also added a `depends_on: nginx` to the frontend container. Nginx adds its own `index.html` when it starts, and it can overwrite the copied template. With this dependency, we guarantee that the shown `index.html` is the one we copied.