### PR TITLE
Set REACT_APP_NETWORK_ID for launch-kit-frontend

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -56,6 +56,7 @@ services:${isGanache ? ganacheService : ''}
       REACT_APP_COLLECTIBLE_NAME: '${options.collectibleName}'
       REACT_APP_COLLECTIBLE_DESCRIPTION: '${options.collectibleDescription}'
       REACT_APP_RELAYER_URL: 'http://localhost:3000/v2'
+      REACT_APP_NETWORK_ID: ${networkId}
     command: yarn build
     volumes:
         - frontend-assets:/app/build


### PR DESCRIPTION
Adds support for https://github.com/0xProject/0x-launch-kit-frontend/issues/523, otherwise the frontend will always use the `ganache`/`custom` network ID.