### PR TITLE
Deprecate launch kit backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules/
 lib/
+postgres/
+docker-compose.yml

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Need help or have questions? [Join our Discord](https://discordapp.com/invite/Xv
 npx @0x/launch-kit-wizard && docker-compose up
 ```
 
-2. When Docker is done loading, open your browser to check out your new exchange. It will be running at the port you specified in the wizard (default is http://localhost:3001/)
+2. When Docker is done loading, and the frontend image is done building, open your browser to check out your new exchange. It will be running at the port you specified in the wizard (default is http://localhost:3001/)
 
 [Instructions for using Launch Kit with Ganache](https://hackmd.io/-rC79gYWRyG7h6M9jUf5qA)  
 [Instructions for deploying to AWS](https://github.com/0xProject/0x-launch-kit/wiki/FAQ#aws)
@@ -50,7 +50,7 @@ Launch a 0x relayer in under a minute with Launch Kit. This repository contains 
 Launch Kit is split into two separate repos:
 
 -   **[0x Launch Kit Frontend](https://github.com/0xProject/0x-launch-kit-frontend)**: ERC-20 and ERC-721 relayer UIs
--   **[0x Launch Kit Backend](https://github.com/0xProject/0x-launch-kit-backend)**: 0x relayer server, API, and database that powers Launch Kit
+-   **[0x API](https://github.com/0xProject/0x-api)**: An API that supports the [Standard Relayer API](https://0x.org/docs/api#sra) specification.
 
 This repo contains a Docker image that will run both codebases simultaneously for easy deployment, but you can also clone or fork each repo independently.
 
@@ -58,9 +58,9 @@ This repo contains a Docker image that will run both codebases simultaneously fo
 
 ## Language choice
 
-`0x-launch-kit-backend` ships with 2 codebases, one in Typescript and another in Javascript. Although the Javascript is auto-generated from the Typescript, we made sure the Javascript generated is readable.
+`0x-api` is a Typescript node codebase that uses Express to run an HTTP server.
 
-`0x-launch-kit-frontend` ship with just a TypeScript codebase and uses React + Thunk to create and manage the UI.
+`0x-launch-kit-frontend` is a TypeScript codebase and uses React + Thunk to create and manage the UI.
 
 ## Windows
 Note some installations of Docker on windows don't support forwarding `localhost` to the Docker VM. You may be required to update references of `localhost` to `192.168.99.100` or the `docker-machine ip` equivalent. These values should be replaced during the Wizard prompts and when navigating to the frontend website.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ npx @0x/launch-kit-wizard && docker-compose up
 
 2. When Docker is done loading, and the frontend image is done building, open your browser to check out your new exchange. It will be running at the port you specified in the wizard (default is http://localhost:3001/)
 
-[Instructions for using Launch Kit with Ganache](https://hackmd.io/-rC79gYWRyG7h6M9jUf5qA)  
+[Instructions for using Launch Kit with Ganache](https://github.com/0xProject/0x-launch-kit/wiki/FAQ#development-with-ganache)
 [Instructions for deploying to AWS](https://github.com/0xProject/0x-launch-kit/wiki/FAQ#aws)
 
 ## Table of contents

--- a/src/build.ts
+++ b/src/build.ts
@@ -93,9 +93,9 @@ services:${isGanache ? ganacheService : ''}
         - frontend-assets:/app/build
   backend:
     image: 0xorg/0x-api:latest
-    command: yarn start:service:sra_http
     depends_on: 
         - postgres
+        - mesh
     environment:
         HTTP_PORT: '3000'
         ETHEREUM_RPC_URL: '${options.rpcUrl}'
@@ -110,7 +110,7 @@ services:${isGanache ? ganacheService : ''}
     ports:
       - '3000:3000'
   mesh:
-    image: 0xorg/mesh:8.1.1
+    image: 0xorg/mesh:9.0.1
     restart: always
     environment:
         ETHEREUM_RPC_URL: '${options.rpcUrl}'
@@ -118,7 +118,7 @@ services:${isGanache ? ganacheService : ''}
         USE_BOOTSTRAP_LIST: 'true'
         VERBOSITY: 3
         PRIVATE_KEY_PATH: ''
-        RPC_ADDR: 'mesh:60557'
+        WS_RPC_ADDR: '0.0.0.0:60557'
         # You can decrease the BLOCK_POLLING_INTERVAL for test networks to
         # improve performance. See https://0x-org.gitbook.io/mesh/ for more
         # Documentation about Mesh and its environment variables.

--- a/src/build.ts
+++ b/src/build.ts
@@ -70,6 +70,18 @@ export const buildDockerComposeYml = (options: BuildOptions) => {
     return `
 version: "3"
 services:${isGanache ? ganacheService : ''}
+  postgres:
+    image: postgres:9.6
+    environment:
+        - POSTGRES_USER=api
+        - POSTGRES_PASSWORD=api
+        - POSTGRES_DB=api
+    # persist the postgres data to disk so we don't lose it
+    # on rebuilds.
+    volumes:
+        - ./postgres:/var/lib/postgresql/data
+    ports:
+        - "5432:5432"
   frontend:
     image: 0xorg/launch-kit-frontend:latest
     environment:
@@ -84,10 +96,13 @@ services:${isGanache ? ganacheService : ''}
     volumes:
         - frontend-assets:/app/build
   backend:
-    image: 0xorg/launch-kit-backend:latest
+    image: 0xorg/0x-api:latest
+    command: yarn start:service:sra_http
+    depends_on: 
+        - postgres
     environment:
         HTTP_PORT: '3000'
-        RPC_URL: '${options.rpcUrl}'
+        ETHEREUM_RPC_URL: '${options.rpcUrl}'
         NETWORK_ID: '${networkId}'
         CHAIN_ID: '${chainId}'
         WHITELIST_ALL_TOKENS: 'true'
@@ -95,15 +110,18 @@ services:${isGanache ? ganacheService : ''}
         MAKER_FEE_UNIT_AMOUNT: '${options.makerFee}'
         TAKER_FEE_UNIT_AMOUNT: '${options.takerFee}'
         MESH_ENDPOINT: 'ws://mesh:60557'
+        POSTGRES_URI: 'postgresql://api:api@postgres/api'
     ports:
       - '3000:3000'
   mesh:
-    image: 0xorg/mesh:7-0xv3
+    image: 0xorg/mesh:8.1.1
     restart: always
     environment:
         ETHEREUM_RPC_URL: '${options.rpcUrl}'
         ETHEREUM_CHAIN_ID: '${chainId}'
+        USE_BOOTSTRAP_LIST: 'true'
         VERBOSITY: 3
+        PRIVATE_KEY_PATH: ''
         RPC_ADDR: 'mesh:60557'
         # You can decrease the BLOCK_POLLING_INTERVAL for test networks to
         # improve performance. See https://0x-org.gitbook.io/mesh/ for more

--- a/src/build.ts
+++ b/src/build.ts
@@ -105,7 +105,7 @@ services:${isGanache ? ganacheService : ''}
         FEE_RECIPIENT: '${options.feeRecipient}'
         MAKER_FEE_UNIT_AMOUNT: '${options.makerFee}'
         TAKER_FEE_UNIT_AMOUNT: '${options.takerFee}'
-        MESH_ENDPOINT: 'ws://mesh:60557'
+        MESH_WEBSOCKET_URI: 'ws://mesh:60557'
         POSTGRES_URI: 'postgresql://api:api@postgres/api'
     ports:
       - '3000:3000'

--- a/src/build.ts
+++ b/src/build.ts
@@ -76,10 +76,6 @@ services:${isGanache ? ganacheService : ''}
         - POSTGRES_USER=api
         - POSTGRES_PASSWORD=api
         - POSTGRES_DB=api
-    # persist the postgres data to disk so we don't lose it
-    # on rebuilds.
-    volumes:
-        - ./postgres:/var/lib/postgresql/data
     ports:
         - "5432:5432"
   frontend:

--- a/src/index.ts
+++ b/src/index.ts
@@ -136,7 +136,7 @@ async function main() {
             name: 'relayerUrl',
             message:
                 'Launch Kit will create a backend Relayer. Enter the public URL for the backend Relayer or leave default:',
-            default: 'http://localhost:3000/v3',
+            default: 'http://localhost:3000/sra/v3',
             validate: (rpcUrl: string) => {
                 return /https?:\/\/.+/.test(rpcUrl) ? true : 'Please enter a valid URL';
             },
@@ -146,7 +146,7 @@ async function main() {
             name: 'relayerWebsocketUrl',
             message:
                 'Launch Kit will create a backend Relayer. Enter the public URL for the backend websocket or leave default:',
-            default: 'ws://localhost:3000/',
+            default: 'ws://localhost:3000/sra/v3',
             validate: (rpcUrl: string) => {
                 return /wss?:\/\/.+/.test(rpcUrl) ? true : 'Please enter a valid Websocket URL';
             },


### PR DESCRIPTION
After this merges I need to:
1. Run the publish step.
2. Update https://hackmd.io/-rC79gYWRyG7h6M9jUf5qA.
3. Update https://github.com/0xProject/0x-launch-kit/wiki/FAQ.

Missing anything?